### PR TITLE
refactor: 移除情绪分类部分的条件渲染

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -182,7 +182,7 @@
                     {% endif %}
                 </div>
                 <!-- 情绪分类部分 -->
-                {% if not is_search %}
+                
                 <div class="category">
                     <h3>情绪分类</h3>
                     <ul>
@@ -194,7 +194,7 @@
                         <li><a href="{{ url_for('diary.search_by_emotion', emotion_type='烦闷') }}">😤 烦闷</a></li>
                     </ul>
                 </div>
-                {% endif %}
+                
                 <!-- 搜索框部分 -->
                 <div class="search-box">
                     <form action="{{ url_for('diary.search') }}" method="GET">


### PR DESCRIPTION
移除 `index.html` 中情绪分类部分的 `{% if not is_search %}` 条件渲染，简化模板逻辑，使其始终显示